### PR TITLE
[FEAT] 공통 버튼,버튼 컨테이너 #7

### DIFF
--- a/google-finance/src/App.jsx
+++ b/google-finance/src/App.jsx
@@ -2,14 +2,11 @@ import { useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { GlobalStyle } from './styles/globalStyle';
 import theme from './styles/theme';
-import { St } from './components/Common/buttons';
 function App() {
   const [count, setCount] = useState(0);
-
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <St.CommonButton>미국</St.CommonButton>
     </ThemeProvider>
   );
 }

--- a/google-finance/src/App.jsx
+++ b/google-finance/src/App.jsx
@@ -2,12 +2,14 @@ import { useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { GlobalStyle } from './styles/globalStyle';
 import theme from './styles/theme';
+import { St } from './components/Common/buttons';
 function App() {
   const [count, setCount] = useState(0);
 
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
+      <St.CommonButton>아시아</St.CommonButton>
     </ThemeProvider>
   );
 }

--- a/google-finance/src/App.jsx
+++ b/google-finance/src/App.jsx
@@ -9,7 +9,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <St.CommonButton>아시아</St.CommonButton>
+      <St.CommonButton>미국</St.CommonButton>
     </ThemeProvider>
   );
 }

--- a/google-finance/src/components/Common/buttons.jsx
+++ b/google-finance/src/components/Common/buttons.jsx
@@ -2,9 +2,16 @@ import styled from 'styled-components';
 import theme from '../../styles/theme';
 
 const St = {
+  CommonButtonContainer: styled.div`
+    display: flex;
+    align-items: center;
+
+    gap: 1rem;
+  `,
   CommonButton: styled.button`
     height: 3rem;
     padding: 0.8rem 1.4rem;
+    gap: 1rem;
 
     border-radius: 1.5rem;
     ${theme.fonts.roboto_12_cond};

--- a/google-finance/src/components/Common/buttons.jsx
+++ b/google-finance/src/components/Common/buttons.jsx
@@ -11,6 +11,12 @@ const St = {
     background-color: ${theme.colors.gray_4};
     color: ${theme.colors.gray_2};
     border: none;
+
+    &:active,
+    &:focus {
+      background-color: ${theme.colors.blue_background};
+      color: ${theme.colors.blue_main};
+    }
   `,
 };
 

--- a/google-finance/src/components/Common/buttons.jsx
+++ b/google-finance/src/components/Common/buttons.jsx
@@ -1,2 +1,17 @@
 import styled from 'styled-components';
 import theme from '../../styles/theme';
+
+const St = {
+  CommonButton: styled.button`
+    height: 3rem;
+    padding: 0.8rem 1.4rem;
+
+    border-radius: 1.5rem;
+    ${theme.fonts.roboto_12_cond};
+    background-color: ${theme.colors.gray_4};
+    color: ${theme.colors.gray_2};
+    border: none;
+  `,
+};
+
+export { St };

--- a/google-finance/src/components/Common/buttons.jsx
+++ b/google-finance/src/components/Common/buttons.jsx
@@ -1,0 +1,2 @@
+import styled from 'styled-components';
+import theme from '../../styles/theme';

--- a/google-finance/src/styles/theme.js
+++ b/google-finance/src/styles/theme.js
@@ -99,6 +99,15 @@ const fonts = {
     line-height: normal;
     letter-spacing: -0.06rem;
   `,
+  roboto_12_cond: css`
+    font-family: 'Roboto';
+    font-size: 1.2rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    letter-spacing: -0.06rem;
+  `,
+
   roboto_14: css`
     font-family: 'Roboto';
     font-size: 1.4rem;


### PR DESCRIPTION
## 🔥 Related Issues
- closed #7 
<!-- 해당 pr을 merge할 때 이슈를 자동으로 닫으려면, closed #1과 같이 작성해주세요 -->

## 💙 작업 내용

- [x]  아무 동작이 없을때의 버튼
- [x]  클릭 시의 버튼
- [x] 버튼들을 담는 버튼 컨테이너 

+) theme font에 roboto_12_cond가 빠져있어서 이 부분도 추가했습니다~~

## ✅ PR Point
`CommonButton`, `CommonButtonContainer`로 네이밍했는데, 
`Button`, `ButtonContainer` 가 나을까요? 이름이 좀 긴 거 같기도 해서..
근데 또 공통이라는 의미가 중요할 거 같기도 하고..


## 👀 스크린샷 / GIF / 링크

```
import { St } from './components/Common/buttons';
      <St.CommonButtonContainer>
        <St.CommonButton>미국</St.CommonButton>
        <St.CommonButton>아시아</St.CommonButton>
      </St.CommonButtonContainer>
```

<img width="131" alt="Screenshot 2023-11-21 at 6 31 24 PM" src="https://github.com/DOSOPT-CDS-WEB-TEAM2/CLIENT/assets/93575538/db7afc13-9e9f-4f9f-a91b-31e889fa2589">

왼: 아무 동작 없을 때 / 오: 버튼을 클릭했을 때

